### PR TITLE
Render variables in entire config not only alias

### DIFF
--- a/cli/commands/deploy.js
+++ b/cli/commands/deploy.js
@@ -14,8 +14,8 @@ const confirm = async message => {
       type: "confirm",
       name: "confirmed",
       message: yellow(message),
-      default: false,
-    },
+      default: false
+    }
   ]);
 
   if (!confirmed) {
@@ -62,7 +62,12 @@ const deploy = U.createCommand((args, options, logger) => {
     deployer(env.options, logger);
   };
 
-  R.pipe(U.readConfig, U.decryptConfig(key), performDeploy)(configPath);
+  R.pipe(
+    U.readConfig,
+    U.decryptConfig(key),
+    U.renderConfig(process.env),
+    performDeploy
+  )(configPath);
 });
 
 module.exports = deploy;

--- a/cli/deployers/now.js
+++ b/cli/deployers/now.js
@@ -17,7 +17,7 @@ const deploy = (token, vars) =>
     token,
     ...envVars(vars),
     "--no-clipboard",
-    "deploy",
+    "deploy"
   ]);
 
 const alias = (token, fromURL, toURL) =>

--- a/cli/deployers/now.js
+++ b/cli/deployers/now.js
@@ -1,5 +1,4 @@
 const R = require("ramda");
-const mustache = require("mustache");
 const childProcess = require("child_process");
 const { green } = require("chalk");
 
@@ -27,11 +26,10 @@ const alias = (token, fromURL, toURL) =>
 const now = (options, logger) => {
   logger.info("Deploying to ▲ now...");
 
-  const aliasURL = mustache.render(options.alias, process.env);
   const deployURL = deploy(options.token, options.vars).trim();
-  alias(options.token, deployURL, aliasURL);
+  alias(options.token, deployURL, options.alias);
 
-  logger.info(green("Success! Deployed to %s (%s)"), deployURL, aliasURL);
+  logger.info(green("Success! Deployed to %s (%s)"), deployURL, options.alias);
 };
 
 module.exports = now;

--- a/cli/deployers/test.js
+++ b/cli/deployers/test.js
@@ -19,7 +19,7 @@ const deploy = (token, vars) => {
       token,
       ...envVars(vars),
       "--no-clipboard",
-      "deploy",
+      "deploy"
     ].join(" ")
   );
 

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -75,7 +75,6 @@ const encryptObject = R.curry((key, obj) => {
 
 const renderObject = R.curry((context, obj) => {
   const render = (value, prop) => {
-    console.log(`rendering ${value}`);
     return mustache.render(value, context);
   };
 

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const mustache = require("mustache");
 const path = require("path");
 const R = require("ramda");
 const YAML = require("js-yaml");
@@ -72,9 +73,20 @@ const encryptObject = R.curry((key, obj) => {
   return processObject(value => encryptor.encrypt(value), obj);
 });
 
+const renderObject = R.curry((context, obj) => {
+  const render = (value, prop) => {
+    console.log(`rendering ${value}`);
+    return mustache.render(value, context);
+  };
+
+  return processObject(render, obj);
+});
+
 const decryptConfig = decryptObject;
 
 const encryptConfig = encryptObject;
+
+const renderConfig = renderObject;
 
 const createCommand = cb => (args, options, logger) => {
   try {
@@ -105,6 +117,7 @@ module.exports = {
   createCommand,
   decryptConfig,
   encryptConfig,
+  renderConfig,
   getMergedEnv,
-  dumpYAML,
+  dumpYAML
 };


### PR DESCRIPTION
Notes:
- I've moved the logic into the `commands/deploy.js` command code instead of the `deployers/now.js` code because it makes more sense to me (didn't see how is it relevant only to **now**)

fixes #3 